### PR TITLE
fix transformblock calls, remove tf function

### DIFF
--- a/tabnet/custom_objects.py
+++ b/tabnet/custom_objects.py
@@ -18,6 +18,7 @@ def glu(x, n_units=None):
 Code replicated from https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/sparsemax.py
 """
 @register_keras_custom_object
+@tf.function
 def sparsemax(logits, axis=-1):
     """Sparsemax activation function [1].
     For each batch `i` and class `j` we have
@@ -70,6 +71,7 @@ def _swap_axis(logits, dim_index, last_index, **kwargs):
         ], 0), **kwargs)
 
 
+@tf.function
 def _compute_2d_sparsemax(logits):
     """Performs the sparsemax operation when axis=-1."""
     shape_op = tf.shape(logits)

--- a/tabnet/custom_objects.py
+++ b/tabnet/custom_objects.py
@@ -18,7 +18,6 @@ def glu(x, n_units=None):
 Code replicated from https://github.com/tensorflow/addons/blob/master/tensorflow_addons/activations/sparsemax.py
 """
 @register_keras_custom_object
-@tf.function
 def sparsemax(logits, axis=-1):
     """Sparsemax activation function [1].
     For each batch `i` and class `j` we have
@@ -71,7 +70,6 @@ def _swap_axis(logits, dim_index, last_index, **kwargs):
         ], 0), **kwargs)
 
 
-@tf.function
 def _compute_2d_sparsemax(logits):
     """Performs the sparsemax operation when axis=-1."""
     shape_op = tf.shape(logits)

--- a/tabnet/tabnet.py
+++ b/tabnet/tabnet.py
@@ -7,8 +7,8 @@ class TransformBlock(tf.keras.Model):
     def __init__(self, features,
                  norm_type,
                  momentum=0.9,
-                 groups=2,
                  virtual_batch_size=None,
+                 groups=2,
                  block_name='',
                  **kwargs):
         super(TransformBlock, self).__init__(**kwargs)
@@ -169,20 +169,29 @@ class TabNet(tf.keras.Model):
             self.input_features = None
             self.input_bn = None
 
-        self.transform_f1 = TransformBlock(2 * self.feature_dim, self.batch_momentum, self.virtual_batch_size,
-                                           self.num_groups, block_name='f1')
-        self.transform_f2 = TransformBlock(2 * self.feature_dim, self.batch_momentum, self.virtual_batch_size,
-                                           self.num_groups, block_name='f2')
-        self.transform_f3_list = [TransformBlock(2 * self.feature_dim, self.batch_momentum, self.virtual_batch_size,
-                                           self.num_groups, block_name=f'f3_{i}')
-                                           for i in range(self.num_decision_steps)]
-        self.transform_f4_list = [TransformBlock(2 * self.feature_dim, self.batch_momentum, self.virtual_batch_size,
-                                           self.num_groups, block_name=f'f4_{i}')
-                                           for i in range(self.num_decision_steps)]
+        self.transform_f1 = TransformBlock(2 * self.feature_dim, self.norm_type,
+                self.batch_momentum, self.virtual_batch_size, self.num_groups, block_name='f1')
 
-        self.transform_coef_list = [TransformBlock(self.num_features, self.batch_momentum, self.virtual_batch_size,
-                                             self.num_groups, block_name=f'coef_{i}')
-                                             for i in range(self.num_decision_steps-1)]
+        self.transform_f2 = TransformBlock(2 * self.feature_dim, self.norm_type,
+                self.batch_momentum, self.virtual_batch_size, self.num_groups, block_name='f2')
+
+        self.transform_f3_list = [
+            TransformBlock(2 * self.feature_dim, self.norm_type,
+                self.batch_momentum, self.virtual_batch_size, self.num_groups, block_name=f'f3_{i}')
+            for i in range(self.num_decision_steps)
+        ]
+
+        self.transform_f4_list = [
+            TransformBlock(2 * self.feature_dim, self.norm_type,
+                self.batch_momentum, self.virtual_batch_size, self.num_groups, block_name=f'f4_{i}')
+            for i in range(self.num_decision_steps)
+        ]
+
+        self.transform_coef_list = [
+            TransformBlock(self.num_features, self.norm_type,
+                self.batch_momentum, self.virtual_batch_size, self.num_groups, block_name=f'coef_{i}')
+            for i in range(self.num_decision_steps-1)
+        ]
 
 
         self._step_feature_selection_masks = None


### PR DESCRIPTION
- `TransformBlock` was being called incorrectly
  - `norm_type` wasn't being provided, but the positional args call meant that it was using the `batch_momentum`. This effectively prevented batch_norm from being used
  - Once this was fixed, I noticed that `groups` and `virtual_batch_size` were being mixed up, so I switched the argument order (in the function definition due to laziness)
- While this should probably just use tfa directly, there was a [small change](https://github.com/tensorflow/addons/commit/e55167c7e16dc8945809bcc96dd335e72ebf0fa1#diff-f05bc2d568594ae2ac58eaf41b38752aL85) there to remove the `tf.function` decorator so that's replicated here.

Both of these were done in the hopes it would help https://github.com/titu1994/tf-TabNet/issues/9, but I haven't observed any significant change there (even using the new batch normalization)